### PR TITLE
Refactor command palette rendering

### DIFF
--- a/module/KeyHandlers/CommandPalette.ps1
+++ b/module/KeyHandlers/CommandPalette.ps1
@@ -4,200 +4,27 @@ function CommandPalette {
         [object] $arg
     )
     end {
-        # Save the current buffer, cursor position, selection range and selection command count to
-        # be restored after the command is found.
-        function ExportState {
-            $start = $length = $cursor = $inputBuffer = $null
-            [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$inputBuffer, [ref]$cursor)
-            [Microsoft.PowerShell.PSConsoleReadLine]::GetSelectionState([ref]$start, [ref]$length)
-            if ($start -ne -1) {
-                $selectionState = [PSCustomObject]@{
-                    Start    = $start
-                    End      = $start + $length
-                    Commands = $instance.GetType().
-                        GetField('_visualSelectionCommandCount', $instanceFlags).
-                        GetValue($instance)
-                }
+        $resultGetter = {
+            param([string] $Query)
+            end {
+                return Get-PSWritelineKeyHandler -Name "*$Query*"
             }
-            return [PSCustomObject]@{
-                PSTypeName  = 'PSReadLineBufferState'
-                InputBuffer = $inputBuffer
-                CursorIndex = $cursor
-                Selection   = $selectionState
+        }
+        $resultFormatter = {
+            param([psobject] $Handler)
+            end {
+                return '{0} - {1}' -f $Handler.Name, $Handler.Description
             }
         }
 
-        # Import inital state after command is found.
-        function ImportState([PSTypeName('PSReadLineBufferState')] $state) {
-            [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()
+        $result = InvokeStatusPrompt `
+            -Prompt 'Command Search' `
+            -ResultGetterCallback $resultGetter `
+            -ResultFormatterCallback $resultFormatter
 
-            $promptBuffer.Clear()
+        if (-not $result) { return }
 
-            if ($state.InputBuffer) {
-                [Microsoft.PowerShell.PSConsoleReadLine]::Insert($state.InputBuffer)
-            }
-
-            if ($state.Selection) {
-                $start = $state.Selection.Start
-                $end   = $state.Selection.End
-                if ($state.Selection.Start -eq $state.CursorIndex) {
-                        $start = $state.Selection.End
-                        $end   = $state.Selection.Start
-                }
-                [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition($start)
-
-                $instance.GetType().
-                    GetMethod('VisualSelectionCommon', $instanceFlags).
-                    CreateDelegate([Action[Action]], $instance).
-                    Invoke({ [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition($end) })
-
-                $instance.GetType().
-                    GetField('_visualSelectionCommandCount', $instanceFlags).
-                    SetValue($instance, $state.Selection.Commands + 1)
-
-            } elseif ($state.CursorIndex) {
-                [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition($state.CursorIndex)
-            }
-        }
-
-        function RenderPrompt {
-            [Microsoft.PowerShell.PSConsoleReadLine].
-                GetMethod('Render', $instanceFlags).
-                Invoke($instance, @())
-        }
-
-        # Draw the current search prompt
-        function RenderPalette {
-            # Setting this to 0 clears selection
-            $instance.GetType().
-                GetField('_visualSelectionCommandCount', $instanceFlags).
-                SetValue($instance, 0)
-
-            [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()
-            $promptBuffer.Clear()
-            $currentMatch = GetCurrentMatch
-            if ($currentMatch) {
-                $null = $promptBuffer.AppendFormat('{0} - {1}', $currentMatch.Name, $currentMatch.Description)
-            }
-            $null = $promptBuffer.Append("`n").
-                Append('CommandSearch: ').
-                Append($buffer)
-
-            RenderPrompt
-        }
-
-        function UpdateMatches([string] $searchTerms) {
-            if ($searchTerms.Length) {
-                # $matchList = Get-PSReadlineKeyHandler | Where-Object 'Function' -Like "*$searchTerms*"
-                $matchList = Get-PSWritelineKeyHandler -Name "*$searchTerms*"
-            } else {
-                $matchList = $null
-            }
-            $currentMatchIndex = 0
-        }
-
-        function GetCurrentMatch {
-            if (-not $matchList) { return }
-
-            if ($matchList.Count -gt 1) {
-                return $matchList[$currentMatchIndex]
-            }
-            return $matchList
-        }
-
-        # Increment match index (for tab handling)
-        function MoveNext {
-            if ($currentMatchIndex + 1 -eq $matchList.Count) {
-                $currentMatchIndex = 0
-                return
-            }
-            $currentMatchIndex++
-        }
-
-        # Decrement match index (for shift tab handling)
-        function MovePrevious {
-            if ($currentMatchIndex -eq 0) {
-                $currentMatchIndex = $matchList.Count - 1
-                return
-            }
-            $currentMatchIndex--
-        }
-        function GetHandlerAction {
-            param(
-                [PSTypeName('PSWriteline.Handler')] $Handler
-            )
-            if ($Handler.Action) {
-                return $Handler.Action
-            }
-
-            $realHandler = $dispatchTable.
-                Values.
-                Where({ $_.BriefDescription -eq $Handler.Name }, 'First')
-
-            if (-not $realHandler) {
-                $realHandler = $chordDispatchTable.
-                    Values.
-                    Values.
-                    Where({ $_.BriefDescription -eq $Handler.Name }, 'First')
-            }
-
-            if ($realHandler.ScriptBlock) {
-                return $realHandler.ScriptBlock
-            }
-
-            return [Microsoft.PowerShell.PSConsoleReadLine]::($Handler.Name)
-        }
-
-        # Set defaults/constants and current state.
-        $staticFlags        = [System.Reflection.BindingFlags]'Static, NonPublic'
-        $instanceFlags      = [System.Reflection.BindingFlags]'Instance, NonPublic'
-        $instance           = [Microsoft.PowerShell.PSConsoleReadLine].GetField('_singleton', $staticFlags).GetValue($null)
-        $promptBuffer       = [Microsoft.PowerShell.PSConsoleReadLine].GetField('_buffer', $instanceFlags).GetValue($instance)
-        $dispatchTable      = [Microsoft.PowerShell.PSConsoleReadLine].GetField('_dispatchTable', $instanceFlags).GetValue($instance)
-        $chordDispatchTable = [Microsoft.PowerShell.PSConsoleReadLine].GetField('_chordDispatchTable', $instanceFlags).GetValue($instance)
-        $buffer             = [System.Text.StringBuilder]::new()
-        $matchList          = $null
-        $currentMatchIndex  = 0
-        $bufferState        = ExportState
-
-        # Main input loop.
-        while ($true) {
-            RenderPalette
-            $key = [console]::ReadKey()
-            $null = . {
-                if ($key.Key -eq 'Backspace') {
-                    if ($buffer.Length) {
-                        $buffer.Remove($buffer.Length - 1, 1)
-                        . UpdateMatches $buffer
-                    }
-                } elseif ($key.Key -eq 'Escape') {
-                    ImportState $bufferState
-                    RenderPrompt
-                    break
-                } elseif ($key.Key -eq 'Tab') {
-                    if ($key.Modifiers.HasFlag([ConsoleModifiers]::Shift)) {
-                        . MovePrevious
-                    } else {
-                        . MoveNext
-                    }
-                } elseif ($key.Key -eq 'Enter') {
-                    ImportState $bufferState
-                    RenderPrompt
-
-                    if ($currentMatch = GetCurrentMatch) {
-                        if ($handlerAction = GetHandlerAction -Handler $currentMatch) {
-                            $handlerAction.Invoke()
-                        }
-                    }
-
-                    break
-                } else {
-                    if (-not $key.Modifiers.HasFlag([ConsoleModifiers]::Control)) {
-                        $buffer.Append($key.KeyChar)
-                        . UpdateMatches $buffer
-                    }
-                }
-            }
-        }
+        $action = GetHandlerAction -Handler $result
+        $action.Invoke()
     }
 }

--- a/module/Private/GetHandlerAction.ps1
+++ b/module/Private/GetHandlerAction.ps1
@@ -1,0 +1,34 @@
+function GetHandlerAction {
+    [CmdletBinding()]
+    param(
+        [PSTypeName('PSWriteline.Handler')] $Handler
+    )
+    begin {
+        $flags              = [System.Reflection.BindingFlags]'Instance, NonPublic'
+        $instance           = $script:PSReadlineSingleton
+        $dispatchTable      = $instance.GetType().GetField('_dispatchTable', $flags).GetValue($instance)
+        $chordDispatchTable = $instance.GetType().GetField('_chordDispatchTable', $flags).GetValue($instance)
+    }
+    end {
+        if ($Handler.Action) {
+            return $Handler.Action
+        }
+
+        $realHandler = $dispatchTable.
+            Values.
+            Where({ $_.BriefDescription -eq $Handler.Name }, 'First')
+
+        if (-not $realHandler) {
+            $realHandler = $chordDispatchTable.
+                Values.
+                Values.
+                Where({ $_.BriefDescription -eq $Handler.Name }, 'First')
+        }
+
+        if ($realHandler.ScriptBlock) {
+            return $realHandler.ScriptBlock
+        }
+
+        return [Microsoft.PowerShell.PSConsoleReadLine]::($Handler.Name)
+    }
+}

--- a/module/Private/InvokeStatusPrompt.ps1
+++ b/module/Private/InvokeStatusPrompt.ps1
@@ -1,0 +1,233 @@
+function InvokeStatusPrompt {
+    [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingEmptyCatchBlock', '')]
+    [Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', '')]
+    param(
+        [ValidateNotNull()]
+        [string] $Prompt,
+
+        [ValidateNotNull()]
+        [Func[string, object]] $ResultGetterCallback,
+
+        [ValidateNotNull()]
+        [Func[object, string]] $ResultFormatterCallback
+    )
+    begin {
+        # Save the current buffer, cursor position, selection range and selection command count to
+        # be restored after the command is found.
+        function ExportState {
+            end {
+                $start = $length = $cursor = $inputBuffer = $null
+                [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$inputBuffer, [ref]$cursor)
+                [Microsoft.PowerShell.PSConsoleReadLine]::GetSelectionState([ref]$start, [ref]$length)
+                if ($start -ne -1) {
+                    $selectionState = [PSCustomObject]@{
+                        Start    = $start
+                        End      = $start + $length
+                        Commands = $instance.GetType().
+                            GetField('_visualSelectionCommandCount', $flags).
+                            GetValue($instance)
+                    }
+                }
+
+                return [PSCustomObject]@{
+                    PSTypeName  = 'PSWriteline.BufferState'
+                    InputBuffer = $inputBuffer
+                    CursorIndex = $cursor
+                    Selection   = $selectionState
+                }
+            }
+        }
+
+        # Import inital state after command is found.
+        function ImportState {
+            param([PSTypeName('PSWriteline.BufferState')] $State)
+            end {
+                $null = & {
+                    [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()
+
+                    $buffer.Clear()
+                    $promptState.Prompt.Clear()
+                    $statusPromptField.SetValue($instance, $null)
+
+                    if ($State.InputBuffer) {
+                        [Microsoft.PowerShell.PSConsoleReadLine]::Insert($State.InputBuffer)
+                    }
+
+                    if ($State.Selection) {
+                        $start = $State.Selection.Start
+                        $end   = $State.Selection.End
+                        if ($State.Selection.Start -eq $State.CursorIndex) {
+                                $start = $State.Selection.End
+                                $end   = $State.Selection.Start
+                        }
+
+                        [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition($start)
+
+                        $instance.GetType().
+                            GetMethod('VisualSelectionCommon', $flags).
+                            CreateDelegate([Action[Action]], $instance).
+                            Invoke({ [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition($end) })
+
+                        $instance.GetType().
+                            GetField('_visualSelectionCommandCount', $flags).
+                            SetValue($instance, $State.Selection.Commands + 1)
+
+                    } elseif ($State.CursorIndex) {
+                        [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition($State.CursorIndex)
+                    }
+                }
+            }
+        }
+
+        function RenderPrompt {
+            [Microsoft.PowerShell.PSConsoleReadLine].
+                GetMethod('Render', $flags).
+                Invoke($instance, @())
+        }
+
+        # Draw the current search prompt
+        function RenderPalette {
+            end {
+                $null = & {
+                    # Setting this to 0 clears selection
+                    $instance.GetType().
+                        GetField('_visualSelectionCommandCount', $flags).
+                        SetValue($instance, 0)
+
+                    [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()
+                    $buffer.Clear()
+                    $currentMatch = $promptState.GetCurrent()
+                    if ($currentMatch) {
+                        $resultText = $currentMatch
+                        if ($ResultFormatterCallback) {
+                            $resultText = $ResultFormatterCallback.Invoke($currentMatch)
+                        }
+
+                        $buffer.Append($resultText)
+                    }
+
+                    RenderPrompt
+                }
+            }
+        }
+
+        function UpdateMatches {
+            end {
+                $promptState.MatchList.Clear()
+                if ($promptState.Prompt.Length) {
+                    [object[]]$results = $ResultGetterCallback.Invoke($promptState.Prompt.ToString())
+                    if ($results.Count) {
+                        $promptState.MatchList.AddRange($results)
+                    }
+                }
+
+                $promptState.MatchIndex = 0
+            }
+        }
+
+        function HandleKey {
+            param([ConsoleKeyInfo] $Key, [psobject] $State)
+            switch ($Key.Key) {
+                Backspace {
+                    if ($State.Prompt.Length) {
+                        $null = $State.Prompt.Remove($state.Prompt.Length - 1, 1)
+                        $State.ShouldUpdate = $true
+                    }
+                }
+                Escape {
+                    $State.ShouldExit = $true
+                }
+                Tab {
+                    if ($Key.Modifiers.HasFlag([ConsoleModifiers]::Shift)) {
+                        $State.MoveNext()
+                    } else {
+                        $State.MovePrevious()
+                    }
+                }
+                Enter {
+                    $State.ShouldExit = $true
+                    if ($currentMatch = $State.GetCurrent()) {
+                        return $currentMatch
+                    }
+                }
+                default {
+                    if (-not $Key.Modifiers.HasFlag([ConsoleModifiers]::Control)) {
+                        $null = $State.Prompt.Append($Key.KeyChar)
+                        $State.ShouldUpdate = $true
+                    }
+                }
+            }
+        }
+
+        $flags              = [System.Reflection.BindingFlags]'Instance, NonPublic'
+        $instance           = $script:PSReadlineSingleton
+        $buffer             = $instance.GetType().GetField('_buffer', $flags).GetValue($instance)
+        $statusBuffer       = $instance.GetType().GetField('_statusBuffer', $flags).GetValue($instance)
+        $statusPromptField  = $instance.GetType().GetField('_statusLinePrompt', $flags)
+        $bufferState        = ExportState
+        $promptState        = New-Module -AsCustomObject -ArgumentList $statusBuffer -ScriptBlock {
+            $Prompt       = $args[0]
+            $MatchList    = [System.Collections.Generic.List[object]]::new()
+            $MatchIndex   = 0
+            $ShouldUpdate = $false
+            $ShouldExit   = $false
+
+            function GetCurrent {
+                end {
+                    if (-not $this.MatchList.Count) { return }
+
+                    return $this.MatchList[$this.MatchIndex]
+                }
+            }
+
+            # Increment match index (for tab handling)
+            function MoveNext {
+                end {
+                    if ($this.MatchIndex + 1 -eq $this.MatchList.Count) {
+                        $this.MatchIndex = 0
+                        return
+                    }
+
+                    $this.MatchIndex++
+                }
+            }
+
+            function MovePrevious {
+                end {
+                    if ($this.MatchIndex -eq 0) {
+                        $this.MatchIndex = $this.MatchList.Count - 1
+                        return
+                    }
+
+                    $this.MatchIndex--
+                }
+            }
+
+            Export-ModuleMember -Function * -Variable *
+        }
+    }
+    end {
+        if (-not [string]::IsNullOrEmpty($Prompt)) {
+            $null = $statusPromptField.SetValue($instance, $Prompt + ': ')
+        }
+
+        try {
+            while (-not $promptState.ShouldExit) {
+                $null = RenderPalette
+                $pressedKey = [Console]::ReadKey()
+
+                HandleKey -Key $pressedKey -State $promptState
+                if ($promptState.ShouldUpdate) {
+                    $promptState.ShouldUpdate = $false
+                    UpdateMatches
+                }
+            }
+        } finally {
+            ImportState $bufferState
+            RenderPrompt
+            $null = $statusPromptField.SetValue($instance, $null)
+            $null = $statusBuffer.Clear()
+        }
+    }
+}


### PR DESCRIPTION
- Move command palette render logic to a separate function so it can be reused in future handlers

- Switch to using an object to track state instead of dot scoped variables